### PR TITLE
src: Update to use RateLimitManager#acquire

### DIFF
--- a/monitors/level.js
+++ b/monitors/level.js
@@ -10,7 +10,7 @@ class Level extends Monitor {
     async run(message) {
         if (!message.guild || !message.member || message.command) return;
         try {
-            (this.ratelimits.get(message.author.id) || this.ratelimits.create(message.author.id)).drip();
+            this.ratelimits.acquire(message.author.id).drip();
         } catch(err) {
             // They are ratelimited
             return;


### PR DESCRIPTION
`RateLimitManager#acquire` is a new method added in https://github.com/dirigeants/klasa/pull/442, it allows some code cleanup by changing the `manager.get(id) || manager.create(id)` to only `manager.acquire(id)`.